### PR TITLE
Separate workflows per subproject with path filtering

### DIFF
--- a/.github/workflows/client-format-lint-test.yml
+++ b/.github/workflows/client-format-lint-test.yml
@@ -1,0 +1,75 @@
+name: Client - Format, Lint and Test
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'client/**'
+      - '.github/workflows/client-format-lint-test.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'client/**'
+      - '.github/workflows/client-format-lint-test.yml'
+
+jobs:
+  format-lint-test:
+    name: Format, Lint and Test Client
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        fetch-depth: 0  # Fetch full history for proper git operations
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - name: Install dependencies
+      working-directory: ./client
+      run: npm install
+
+    - name: Run format with auto-fix
+      working-directory: ./client
+      run: npm run format
+      continue-on-error: false
+
+    - name: Check for format changes
+      id: format-changes
+      working-directory: ./client
+      run: |
+        git diff --exit-code || echo "changes_detected=true" >> $GITHUB_OUTPUT
+
+    - name: Commit format changes if any
+      if: steps.format-changes.outputs.changes_detected == 'true'
+      run: |
+        # Store current branch name
+        BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
+        
+        # Navigate to project directory and stage changes
+        cd ./client
+        git config --global user.name "GitHub Actions"
+        git config --global user.email "actions@github.com"
+        git add .
+        
+        # Go back to root for git operations
+        cd ..
+        git commit -m "chore: auto-format client"
+        git fetch origin "$BRANCH_NAME"
+        git checkout "$BRANCH_NAME"
+        git pull origin "$BRANCH_NAME"
+        git push https://x-access-token:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }}.git "$BRANCH_NAME"
+
+    - name: Run lint
+      working-directory: ./client
+      run: npm run lint
+      continue-on-error: false
+
+    - name: Run tests
+      if: success()  # Only run tests if lint passed
+      working-directory: ./client
+      run: npm run test

--- a/.github/workflows/server-format-lint-test.yml
+++ b/.github/workflows/server-format-lint-test.yml
@@ -1,0 +1,75 @@
+name: Server - Format, Lint and Test
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'server/**'
+      - '.github/workflows/server-format-lint-test.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'server/**'
+      - '.github/workflows/server-format-lint-test.yml'
+
+jobs:
+  format-lint-test:
+    name: Format, Lint and Test Server
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        fetch-depth: 0  # Fetch full history for proper git operations
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - name: Install dependencies
+      working-directory: ./server
+      run: npm install
+
+    - name: Run format with auto-fix
+      working-directory: ./server
+      run: npm run format
+      continue-on-error: false
+
+    - name: Check for format changes
+      id: format-changes
+      working-directory: ./server
+      run: |
+        git diff --exit-code || echo "changes_detected=true" >> $GITHUB_OUTPUT
+
+    - name: Commit format changes if any
+      if: steps.format-changes.outputs.changes_detected == 'true'
+      run: |
+        # Store current branch name
+        BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
+        
+        # Navigate to project directory and stage changes
+        cd ./server
+        git config --global user.name "GitHub Actions"
+        git config --global user.email "actions@github.com"
+        git add .
+        
+        # Go back to root for git operations
+        cd ..
+        git commit -m "chore: auto-format server"
+        git fetch origin "$BRANCH_NAME"
+        git checkout "$BRANCH_NAME"
+        git pull origin "$BRANCH_NAME"
+        git push https://x-access-token:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }}.git "$BRANCH_NAME"
+
+    - name: Run lint
+      working-directory: ./server
+      run: npm run lint
+      continue-on-error: false
+
+    - name: Run tests
+      if: success()  # Only run tests if lint passed
+      working-directory: ./server
+      run: npm run test

--- a/.github/workflows/website-format-lint-test.yml
+++ b/.github/workflows/website-format-lint-test.yml
@@ -1,23 +1,21 @@
-name: Format, Lint and Test
+name: Website - Format, Lint and Test
 
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'website/**'
+      - '.github/workflows/website-format-lint-test.yml'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'website/**'
+      - '.github/workflows/website-format-lint-test.yml'
 
 jobs:
   format-lint-test:
-    name: Format, Lint and Test
+    name: Format, Lint and Test Website
     runs-on: ubuntu-latest
-    
-    strategy:
-      matrix:
-        project: [client, server, website]
-      fail-fast: false  # Continue even if one project fails
-    
-    # Only run this job if files in the specific project directory were changed
-    if: contains(github.event.pull_request.changed_files, format('./{0}/', matrix.project))
     
     steps:
     - name: Checkout repository
@@ -32,17 +30,17 @@ jobs:
         node-version: 20
 
     - name: Install dependencies
-      working-directory: ./${{ matrix.project }}
+      working-directory: ./website
       run: npm install
 
     - name: Run format with auto-fix
-      working-directory: ./${{ matrix.project }}
+      working-directory: ./website
       run: npm run format
       continue-on-error: false
 
     - name: Check for format changes
       id: format-changes
-      working-directory: ./${{ matrix.project }}
+      working-directory: ./website
       run: |
         git diff --exit-code || echo "changes_detected=true" >> $GITHUB_OUTPUT
 
@@ -53,25 +51,25 @@ jobs:
         BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
         
         # Navigate to project directory and stage changes
-        cd ./${{ matrix.project }}
+        cd ./website
         git config --global user.name "GitHub Actions"
         git config --global user.email "actions@github.com"
         git add .
         
         # Go back to root for git operations
         cd ..
-        git commit -m "chore: auto-format ${{ matrix.project }}"
+        git commit -m "chore: auto-format website"
         git fetch origin "$BRANCH_NAME"
         git checkout "$BRANCH_NAME"
         git pull origin "$BRANCH_NAME"
         git push https://x-access-token:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }}.git "$BRANCH_NAME"
 
     - name: Run lint
-      working-directory: ./${{ matrix.project }}
+      working-directory: ./website
       run: npm run lint
       continue-on-error: false
 
     - name: Run tests
       if: success()  # Only run tests if lint passed
-      working-directory: ./${{ matrix.project }}
+      working-directory: ./website
       run: npm run test


### PR DESCRIPTION
This PR replaces the single monolithic workflow with three separate workflows (one per subproject) that use GitHub Actions path filtering. This provides better performance and only runs CI checks for subprojects that actually have changes.

## Changes:
- Split `format-lint-test.yml` into three separate workflows
- Each workflow uses `paths` filtering to only trigger when relevant files change
- Client workflow: triggers on changes to `client/**` or the client workflow file itself
- Server workflow: triggers on changes to `server/**` or the server workflow file itself
- Website workflow: triggers on changes to `website/**` or the website workflow file itself

## Benefits:
- Faster CI runs (only affected subprojects run)
- Better resource utilization
- Clearer workflow names and separation of concerns
- Easier to maintain and update individual workflows

## Testing:
- The workflows will automatically trigger when changes are made to their respective subprojects
- All existing functionality is preserved
- Format, lint, and test steps remain unchanged