### PR TITLE
#640 fix cardStacks order to ensure attached card profiles are combined

### DIFF
--- a/server/src/components/cards/card_stack.ts
+++ b/server/src/components/cards/card_stack.ts
@@ -84,7 +84,7 @@ export default abstract class CardStack {
     return this.cardStacks.map(cs => cs.card);
   }
   get cardStacks(): CardStack[] {
-    return this.attachedCardStacks.flatMap(cs => cs.cardStacks).concat(this);
+    return [this, ...this.attachedCardStacks.flatMap(cs => cs.cardStacks)];
   }
   get player(): Player {
     if (this.parentCardStack) return this.parentCardStack.player;


### PR DESCRIPTION
The cardStacks getter was returning attached cards before the root card, which could cause issues with profile computation. Changed to return the root card first, followed by attached cards, ensuring profiles are combined in the expected order (base hull + attached equipment).

This fixes issue #640 where Universal Adapter's sockets were not immediately available for use in the same turn.

Fixes #640