### PR TITLE
fix(server): fix mariadb typings namespace error

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,7 +13,7 @@
         "express": "^4.0.0",
         "mariadb": "^3.0.0",
         "node-fetch": "^2.0.0",
-        "nodemailer": "^8.0.8",
+        "nodemailer": "^8.0.0",
         "nodemon": "^3.0.0",
         "socket.io": "^4.0.0",
         "uuid": "^11.0.0"

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,7 @@
     "express": "^4.0.0",
     "mariadb": "^3.0.0",
     "node-fetch": "^2.0.0",
-    "nodemailer": "^8.0.8",
+    "nodemailer": "^8.0.0",
     "nodemon": "^3.0.0",
     "socket.io": "^4.0.0",
     "uuid": "^11.0.0"

--- a/server/src/components/persistence/db_connector.ts
+++ b/server/src/components/persistence/db_connector.ts
@@ -1,9 +1,9 @@
-import mariadb, { SqlError } from 'mariadb';
+import mariadb, { SqlError, Pool, PoolConnection } from 'mariadb';
 import config from 'config';
 
 export default class DBConnection {
   private static con: DBConnection;
-  pool: mariadb.Pool;
+  pool: Pool;
   private constructor() {
     this.pool = mariadb.createPool({
       host: config.get('database.host'),
@@ -15,7 +15,7 @@ export default class DBConnection {
     });
   }
   async query(query: string, params: any[], noRetry?: boolean): Promise<any> {
-    let conn: mariadb.PoolConnection | undefined;
+    let conn: PoolConnection | undefined;
     try {
       conn = await this.pool.getConnection();
       return conn.prepare(query).then(q => q.execute(params));


### PR DESCRIPTION
Import Pool and PoolConnection directly as named exports from 'mariadb' to resolve compilation issues on Node 26.x / modern TypeScript.